### PR TITLE
instruction: print consecutive qubits as ranges

### DIFF
--- a/src/mimiqcircuits/instruction.py
+++ b/src/mimiqcircuits/instruction.py
@@ -323,7 +323,10 @@ def _string_with_square(arr, sep):
     return (
         "["
         + sep.join(
-            map(lambda e: sep.join(map(str, e)) if isinstance(e, list) else str(e), arr)
+            map(
+                lambda e: f"{e[0]}:{e[-1] + 1}" if isinstance(e, list) else str(e),
+                arr,
+            )
         )
         + "]"
     )


### PR DESCRIPTION
Similar to Python, range a:b denotes the half-open interval [a, b) on the naturals. This makes instructions with large inputs much easier to read.

Before:

>>> c = mimiq.Circuit()
>>> c.push(mimiq.GateX().control(27), 1, 82, 81, *range(8, 28), 45, 90, 4, 52, 353)
354-qubit circuit with 1 instructions:
└── C₂₇X @ q[1,82,81,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,45,90,4,52], q[353]

After:

>>> c = mimiq.Circuit()
>>> c.push(mimiq.GateX().control(27), 1, 82, 81, *range(8, 28), 45, 90, 4, 52, 353)
354-qubit circuit with 1 instructions:
└── C₂₇X @ q[1,82,81,8:28,45,90,4,52], q[353]